### PR TITLE
Removed extra comma after the start script.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "start": "node index.js",
+    "start": "node index.js"
   },
   "dependencies": {
     "express": "^4.21.2"


### PR DESCRIPTION
Removed the extra comma after the start script in `package.json` which was causing `npm install` to fail with the error:  `npm ERR! JSON.parse: package.json must be actual JSON, not just JavaScript.` 